### PR TITLE
Remove assertation when get object instance from handle address to su…

### DIFF
--- a/support-lib/jni/djinni_support.hpp
+++ b/support-lib/jni/djinni_support.hpp
@@ -320,7 +320,6 @@ template <class T> using CppProxyHandle = JniCppProxyCache::Handle<std::shared_p
 template <class T>
 static const std::shared_ptr<T> & objectFromHandleAddress(jlong handle) {
     assert(handle);
-    assert(handle > 4096);
     // Below line segfaults gcc-4.8. Using a temporary variable hides the bug.
     //const auto & ret = reinterpret_cast<const CppProxyHandle<T> *>(handle)->get();
     const CppProxyHandle<T> *proxy_handle =


### PR DESCRIPTION
[MOB-566](https://safetyculture.atlassian.net/browse/MOB-566)
Remove assertion when get object instance from handle address to support Android 11

Tested on Firebase TestLab with Virtual/Real devices and it's working fine : [Firebase Testing Result](https://console.firebase.google.com/u/0/project/project-8638960581077738091/testlab/histories/bh.30cb92ddcaa4b20f/matrices/5336150208375770384)
