### PR TITLE
[MOBUG-238] crash on crux multi threading maintenance

### DIFF
--- a/support-lib/jni/djinni_support.cpp
+++ b/support-lib/jni/djinni_support.cpp
@@ -75,7 +75,7 @@ JNIEnv * jniGetThreadEnv() {
     jint get_res = g_cachedJVM->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6);
     #ifdef EXPERIMENTAL_AUTO_CPP_THREAD_ATTACH
     if (get_res == JNI_EDETACHED) {
-        get_res = g_cachedJVM->AttachCurrentThread(&env, nullptr);
+        get_res = g_cachedJVM->AttachCurrentThreadAsDaemon(&env, nullptr);
         thread_local struct DetachOnExit {
             ~DetachOnExit() {
                 g_cachedJVM->DetachCurrentThread();


### PR DESCRIPTION
Do not use Non-Daemon Thread to avoid keep JVM alive when App ready to killed.